### PR TITLE
Add nodeuv-http, a simple http library in c++ backed by libuv and http parser

### DIFF
--- a/nodeuv-http/README.md
+++ b/nodeuv-http/README.md
@@ -1,0 +1,25 @@
+# C++ LibUV based http server
+
+This is a test of the
+[nodeuv-http](https://github.com/0x00A/nodeuv-http) server (A simple
+http library in c++ backed by libuv and http-parser.)
+
+## Build
+
+```sh
+git clone https://github.com/0x00A/nodeuv-http.git
+cd nodeuv-http
+make
+```
+
+## Start
+
+```sh
+$ ./server
+```
+
+## Bench
+
+```sh
+$ wrk -t12 -c400 -d30s http://localhost:8000
+```


### PR DESCRIPTION
Hope you accept C++ based contribution in your bench.
On my system (Ubuntu 17.04 wrk is broken, no idea why).
I made the test with ab and end up with similar req/s than the rust version but it takes 17MB of ram instead of 115 for the rust version.